### PR TITLE
feat: optional backup description

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "bootstrap": "npx lerna bootstrap --hoist",
     "prettier": "prettier --write \"**/*.*(js|jsx|ts|tsx|json|md)\"",
     "docs": "typedoc --plugin typedoc-plugin-markdown",
-    "test": "lerna run test",
-    "build": "lerna run build"
+    "test": "lerna run test --stream",
+    "build": "lerna run build --stream",
+    "publish": "lerna publish --yes",
+    "canary": "lerna publish --canary --preid beta --yes"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "main": "index.js",
   "scripts": {
     "cz": "git-cz",
-    "postinstall": "lerna bootstrap",
     "bootstrap": "npx lerna bootstrap --hoist",
-    "test": "lerna run test",
     "prettier": "prettier --write \"**/*.*(js|jsx|ts|tsx|json|md)\"",
-    "docs": "typedoc --plugin typedoc-plugin-markdown"
+    "docs": "typedoc --plugin typedoc-plugin-markdown",
+    "test": "lerna run test",
+    "build": "lerna run build"
   },
   "repository": {
     "type": "git",

--- a/packages/cli/src/commands/backup.ts
+++ b/packages/cli/src/commands/backup.ts
@@ -4,10 +4,10 @@ import { runCommandAction } from "../utils/run";
 
 export const useBackupCommand = (cli: Command, runtime: Runtime) => {
 	cli
-		.command('backup [name]')
+		.command('backup <name> [description]')
 		.alias('b')
-		.description('Backup a project by its name')
-		.action(async (name: string) => {
+		.description('Backup a project by its name and add an optional description')
+		.action(async (name: string, description: string) => {
 			await runCommandAction(async spinner => {
 				spinner.start('Saving project ...');
 
@@ -17,7 +17,7 @@ export const useBackupCommand = (cli: Command, runtime: Runtime) => {
 					throw new Error(`Could not find project "${name}", please save it first`)
 				}
 
-				const result = await runtime.projects.backup(project.id);
+				const result = await runtime.projects.backup(project.id, description);
 				const backupSize = formatBytes(result.archive.bytes, 1);
 
 				spinner.succeed(`Created backup v${result.version} for "${project.data.name}" (~ ${backupSize})`);

--- a/packages/core/src/manager/ProjectManager.ts
+++ b/packages/core/src/manager/ProjectManager.ts
@@ -83,7 +83,7 @@ export class ProjectManager extends Manager {
 		return result;
 	}
 
-	public async backup(projectOrId: string | IDatabaseEntry<IProjectSchema>) {
+	public async backup(projectOrId: string | IDatabaseEntry<IProjectSchema>, description = '') {
 		const projectId = typeof projectOrId === 'string' ? projectOrId : projectOrId.id;
 		const project = this.getById(projectId);
 
@@ -106,6 +106,7 @@ export class ProjectManager extends Manager {
 		});
 
 		await this.backups.save({
+			description,
 			ref: project.id,
 			name: `${project.data.name} v${targetVersion}`,
 			version: targetVersion,

--- a/packages/core/src/schema/Project.ts
+++ b/packages/core/src/schema/Project.ts
@@ -8,6 +8,7 @@ export interface IProjectSchema {
 
 export interface IProjectBackupSchema {
 	name: string;
+	description: string;
 	ref: string; // reference to the project ID
 	version: number;
 	path: string;

--- a/packages/core/test/manager/ProjectManager.rls.test.ts
+++ b/packages/core/test/manager/ProjectManager.rls.test.ts
@@ -73,4 +73,19 @@ describe('Core > Manager > Project Manager (RLS)', () => {
 
 		expect(res).toBeTruthy();
 	});
+
+	it('should backup projects with description correctly', async () => {
+		const project = await pm.save({
+			name: 'Example Project',
+			path: fixtureProjectPath,
+		});
+
+		// should be ablet to backup a project
+		const res = await pm.backup(project.id, 'Some backup description');
+
+		const foundBackups = pm.getBackupsByRef(project.id);
+		expect(res).toBeTruthy();
+		expect(foundBackups.backups).toHaveLength(1);
+		expect(foundBackups.backups[0].data.description).toEqual('Some backup description');
+	});
 });

--- a/packages/core/test/manager/ProjectManager.test.ts
+++ b/packages/core/test/manager/ProjectManager.test.ts
@@ -137,23 +137,4 @@ describe('Core > Manager > ProjectManager', () => {
 			expect(foundProject!.data!.sets![0]).toEqual('/some/project/path/MySet.als');
 		});
 	});
-
-	describe('real life scenarios', () => {
-		beforeEach(() => {
-			jest.clearAllMocks();
-			jest.resetAllMocks();
-		});
-
-		it.skip('should work in real life', async () => {
-			const root = resolve(TEMP_TARGET_DIR, 'pm-rls');
-			const pm = new ProjectManager(root);
-			await pm.init();
-			await pm.save({
-				name: 'Example Project',
-				path: resolve(FIXTURES_DIR, 'Example Project'),
-			});
-
-			const foundProject = pm.getByName('Example Project');
-		});
-	});
 });

--- a/packages/core/test/manager/TemplateManager.test.ts
+++ b/packages/core/test/manager/TemplateManager.test.ts
@@ -50,7 +50,7 @@ describe('Core > Manager > TemplateManager', () => {
 			expect(fsMock.readFile).toHaveBeenCalledTimes(0);
 			expect(fsMock.writeFile).toHaveBeenCalledTimes(1);
 			expect(fsMock.writeFile).toHaveBeenLastCalledWith(
-				'/test/database.json',
+				'/test/templates.json',
 				JSON.stringify({ name: 'templates', entries: [] }, null, 2)
 			);
 		});
@@ -80,7 +80,7 @@ describe('Core > Manager > TemplateManager', () => {
 			await tm.init();
 
 			expect(fsMock.readFile).toHaveBeenCalledTimes(1);
-			expect(fsMock.readFile).toHaveBeenLastCalledWith('/test/database.json', 'utf8');
+			expect(fsMock.readFile).toHaveBeenLastCalledWith('/test/templates.json', 'utf8');
 			expect(tmdb.contents.entries).toHaveLength(1);
 			expect(tmdb.contents.entries[0]!.data.name).toEqual('test-template');
 		});

--- a/packages/core/test/manager/__snapshots__/TemplateManager.test.ts.snap
+++ b/packages/core/test/manager/__snapshots__/TemplateManager.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Core > Manager > TemplateManager should be instanciable without options
 Object {
   "database": Database {
     "config": Object {
-      "fileName": "database",
+      "fileName": "templates",
       "name": "templates",
       "root": ".",
     },


### PR DESCRIPTION
Allow extra backup description in ProjectManager and CLI:

```ts
const pm = new ProjectManager();
await pm.init();

const myProject = pm.getByName('My Project');
await pm.backup(myProject.id, 'This version is just for fun');
```

```bash
ableton-tools backup "My Project"  "Some description here"
```